### PR TITLE
fix: Dialog breaking on page reload

### DIFF
--- a/packages/frontend/src/components/ui/dialog.rs
+++ b/packages/frontend/src/components/ui/dialog.rs
@@ -11,8 +11,9 @@ pub struct DialogContext {
 
 impl DialogContext {
     #[allow(dead_code)]
-    pub fn new() -> Self {
-        DialogContext { id: Uuid::new_v4() }
+    #[must_use]
+    pub fn new(uuid: Uuid) -> Self {
+        DialogContext { id: uuid }
     }
 }
 
@@ -33,7 +34,8 @@ impl DialogContext {
 /// ```
 #[component]
 pub fn Dialog(children: Element) -> Element {
-    use_context_provider(|| Signal::new(DialogContext::new()));
+    let dialog_id = use_server_cached(Uuid::new_v4);
+    use_context_provider(|| Signal::new(DialogContext::new(dialog_id)));
 
     children
 }


### PR DESCRIPTION
Fixes the Dialog not working after a page refresh. This is due to a hydration error because of the discrepancy in state between server and frontend